### PR TITLE
Update and fix deprecation warnings

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -2,8 +2,8 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.37.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5398BD6C2ABA17338F676F42F404B9B7BABE1C8DC7380031ACB05BBE1BCF3742" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "gleam_stdlib", version = "0.58.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "091F2D2C4A3A4E2047986C47E2C2C9D728A4E068ABB31FDA17B0D347E6248467" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
 ]
 
 [requirements]

--- a/src/qcheck_gleeunit_utils/run.gleam
+++ b/src/qcheck_gleeunit_utils/run.gleam
@@ -41,9 +41,9 @@ import gleam/dynamic.{type Dynamic}
 @target(erlang)
 import gleam/list
 @target(erlang)
-import gleam/result
-@target(erlang)
 import gleam/string
+@target(erlang)
+import gleam/dynamic/decode
 
 @target(erlang)
 fn do_run_in_parallel() -> Nil {
@@ -55,8 +55,7 @@ fn do_run_in_parallel() -> Nil {
     |> list.map(dangerously_convert_string_to_atom(_, Utf8))
     |> Inparallel
     |> run_eunit(options)
-    |> dynamic.result(dynamic.dynamic, dynamic.dynamic)
-    |> result.unwrap(Error(dynamic.from(Nil)))
+    |> decode.run(decode.dynamic)
 
   let code = case result {
     Ok(_) -> 0


### PR DESCRIPTION
Updates `gleam_stdlib` and `gleeunit` to the latest versions, and fixes the deprecation warnings caused by [`dynamic.result`](https://hexdocs.pm/gleam_stdlib/gleam/dynamic.html#result) and [`dynamic.dynamic`](https://hexdocs.pm/gleam_stdlib/gleam/dynamic.html#dynamic).